### PR TITLE
Move heading to end for readability

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -26,7 +26,7 @@ document.querySelectorAll('.markdown-body').forEach(function(commentBody) {
 
     headingPrefix.setAttribute('aria-hidden', 'true');
     headingPrefix.style = "color: purple; right: 0; position: absolute;";
-    headingPrefix.textContent = ` ${heading.tagName}`;
+    headingPrefix.textContent = ` ${heading.tagName.toLowerCase()}`;
 
     heading.append(headingPrefix);
   });

--- a/contentScript.js
+++ b/contentScript.js
@@ -21,12 +21,13 @@ document.querySelectorAll('.markdown-body').forEach(function(commentBody) {
 
   // Appends heading level to headings. This is hidden from accesibility tree.
   commentBody.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach(function(heading) {
+    heading.style = 'position: relative;';
     const headingPrefix = document.createElement('span');
 
     headingPrefix.setAttribute('aria-hidden', 'true');
-    headingPrefix.textContent = `${heading.tagName} `;
-    headingPrefix.style = "color: purple;";
+    headingPrefix.style = "color: purple; right: 0; position: absolute;";
+    headingPrefix.textContent = ` ${heading.tagName}`;
 
-    heading.insertBefore(headingPrefix, heading.firstChild);
+    heading.append(headingPrefix);
   });
 });


### PR DESCRIPTION
### Before:
<img width="683" alt="Screenshot of this extension appending heading level right before the heading text" src="https://user-images.githubusercontent.com/16447748/153672290-620daebe-dfe3-454c-9be8-01f8050dd9f2.png">


### After:
<img width="916" alt="Screenshot of this extension appending heading level at end of heading text" src="https://user-images.githubusercontent.com/16447748/153683514-e1e2f0d4-92ec-4e84-8554-655363c79c56.png">

