### PR TITLE
Don't run background.js outside of github.com host url exact match

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,3 +1,3 @@
 chrome.webNavigation.onHistoryStateUpdated.addListener(function(details) {
   chrome.tabs.executeScript(details.tabId,{file:"contentScript.js"});
-}, {url: [{hostContains: 'github'}]});
+}, {url: [{hostEquals: 'github.com'}]});


### PR DESCRIPTION
The purpose of the code in `background.js` is to address the issue of the extension only loading on page refresh (resolved by https://github.com/khiga8/github-a11y/pull/5). This was a matter of how github.com does page transitions in features like issues and discussions. We don't care to run this on other github owned domains. 