### PR TITLE
Fix heading position styles to prevent overlap and extract styles into CSS file

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This extension will only run on GitHub domain and does the folowing on all markd
 <img width="916" alt="Example screenshots of purple heading levels appended in at end of heading text line inside a GitHub markdown" src="https://user-images.githubusercontent.com/16447748/153683612-1b7d5975-ed45-4985-892d-6fd64545d18d.png">
 
 
-**Note**: This is  currently not customizable and the styling I've set may not be suitable for all users. Feel free to customize this however you like when you download these files. You can do this by modifying `contentScript.js` to your preferred styling. Then press `Update` on `chrome://extensions/` so changes are reflected in extension.
+**Note**: This is currently not customizable and the styling I've set may not be suitable for all users. Feel free to customize this however you like when you download these files. You can do this by modifying `styles.css` to your preferred styling. Then press `Update` on `chrome://extensions/` so changes are reflected in extension.
 
 ## Resources
 
@@ -42,4 +42,4 @@ This extension will only run on GitHub domain and does the folowing on all markd
 
 ## Bug?
 
-If you encounter a bug, please file a ticket. Pull requests welcome.
+If you encounter a bug, please file a ticket. Contributions welcome.

--- a/contentScript.js
+++ b/contentScript.js
@@ -3,17 +3,17 @@ document.querySelectorAll('.markdown-body').forEach(function(commentBody) {
   commentBody.querySelectorAll('img').forEach(function(image) {
     const altText = image.getAttribute('alt');
     if (!altText) {
-        image.style = 'border: 10px solid red;'
+        image.classList.add('github-a11y-img-missing-alt')
     } else {
         const closestParagraph = image.closest('p');
         if (!closestParagraph) return; // TODO: handle when image is nested in elements like a table cell.
 
-        closestParagraph.style = "position: relative; padding: 0; margin: 0;";
+        closestParagraph.classList.add('github-a11y-img-container');
 
         const subtitle = document.createElement('span');
         subtitle.setAttribute('aria-hidden', 'true');
         subtitle.textContent = altText;
-        subtitle.style = 'display: block; background-color: #121212; padding: 0.5em; color: white; position: absolute; bottom: 0.5em; left: 0; font-weight: 700; z-index: 2; width: 100%; font-size: 1.0rem; opacity: 0.6;';
+        subtitle.classList.add('github-a11y-img-caption');
         
         image.insertAdjacentElement('afterend', subtitle);
     }
@@ -21,11 +21,11 @@ document.querySelectorAll('.markdown-body').forEach(function(commentBody) {
 
   // Appends heading level to headings. This is hidden from accesibility tree.
   commentBody.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach(function(heading) {
-    heading.style = 'position: relative;';
+    heading.classList.add('github-a11y-heading');
     const headingPrefix = document.createElement('span');
 
     headingPrefix.setAttribute('aria-hidden', 'true');
-    headingPrefix.style = "color: purple; right: 0; position: absolute;";
+    headingPrefix.classList.add('github-a11y-heading-prefix');
     headingPrefix.textContent = ` ${heading.tagName.toLowerCase()}`;
 
     heading.append(headingPrefix);

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,9 @@
     {
       "matches": ["https://*.github.com/*"],
       "run_at": "document_idle",
+      "css": ["styles.css"],
       "js": ["contentScript.js"]
+
     }
   ],
   "background": {

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "github-a11y",
   "description": "This extension helps increase accessibility mindfulness while using GitHub",
-  "version": "0.2",
+  "version": "0.3",
   "content_scripts": [
     {
       "matches": ["https://*.github.com/*"],

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,35 @@
+.github-a11y-img-container {
+  position: relative; 
+  padding: 0; 
+  margin: 0;
+}
+
+.github-a11y-img-missing-alt {
+  border: 10px solid red;
+}
+
+.github-a11y-img-caption {
+  display: block; 
+  background-color: #121212; 
+  padding: 0.5em; 
+  color: white; 
+  position: absolute; 
+  bottom: 0.5em; 
+  left: 0; 
+  font-weight: 700; 
+  z-index: 2; 
+  width: 100%; 
+  font-size: 1.0rem; 
+  opacity: 0.6;
+}
+
+.github-a11y-heading {
+  display: table; 
+  width: 100%;
+}
+
+.github-a11y-heading-prefix {
+  color: purple; 
+  display: table-cell; 
+  text-align: right;
+}

--- a/styles.css
+++ b/styles.css
@@ -1,13 +1,16 @@
+/* Necessary for image overlay positioning */
 .github-a11y-img-container {
   position: relative; 
   padding: 0; 
   margin: 0;
 }
 
+/* For when image is missing alt text */
 .github-a11y-img-missing-alt {
   border: 10px solid red;
 }
 
+/* For image overlay */
 .github-a11y-img-caption {
   display: block; 
   background-color: #121212; 
@@ -23,11 +26,13 @@
   opacity: 0.6;
 }
 
+/* Necessary for heading positioning */
 .github-a11y-heading {
   display: table; 
   width: 100%;
 }
 
+/* For appended heading text */
 .github-a11y-heading-prefix {
   color: purple; 
   display: table-cell; 


### PR DESCRIPTION
This PR improves the heading position CSS to not use absolute positioning for aligning the appended heading level text. The reason is because if the heading text is very long, the appended text can end up overlapping. Instead, we use table cell CSS to position the appended heading level to right of end of line (Reference: https://stackoverflow.com/a/17175726).

We also extract the styles into a CSS file to allow for easier customization. Applying styles via classname instead of through inline styling also will make it easier to debug when there are issues. We update README accordingly.

