### PR TITLE
Fix bug where headings get duplicated

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,3 +1,6 @@
 chrome.webNavigation.onHistoryStateUpdated.addListener(function(details) {
-  chrome.tabs.executeScript(details.tabId,{file:"contentScript.js"});
-}, {url: [{hostEquals: 'github.com'}]});
+  console.log("onHistoryStateUpdated", details);
+  chrome.tabs.sendMessage(details.tabId, {
+    type: 'navigation'
+  });
+}, {url: [{hostSuffix: 'github.com'}]});

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,33 +1,44 @@
-document.querySelectorAll('.markdown-body').forEach(function(commentBody) {
-  // Adds alt image overlay. This is hidden from accesibility tree.
-  commentBody.querySelectorAll('img').forEach(function(image) {
-    const altText = image.getAttribute('alt');
-    if (!altText) {
-        image.classList.add('github-a11y-img-missing-alt')
-    } else {
-        const closestParagraph = image.closest('p');
-        if (!closestParagraph) return; // TODO: handle when image is nested in elements like a table cell.
 
-        closestParagraph.classList.add('github-a11y-img-container');
-
-        const subtitle = document.createElement('span');
-        subtitle.setAttribute('aria-hidden', 'true');
-        subtitle.textContent = altText;
-        subtitle.classList.add('github-a11y-img-caption');
-        
-        image.insertAdjacentElement('afterend', subtitle);
-    }
+ function appendAccessibilityInfo() {
+  document.querySelectorAll('.markdown-body').forEach(function(commentBody) {
+    // Adds alt image overlay. This is hidden from accesibility tree.
+    commentBody.querySelectorAll('img').forEach(function(image) {
+      const altText = image.getAttribute('alt');
+      if (!altText) {
+          image.classList.add('github-a11y-img-missing-alt')
+      } else {
+          const closestParagraph = image.closest('p');
+          if (!closestParagraph) return; // TODO: handle when image is nested in elements like a table cell.
+  
+          closestParagraph.classList.add('github-a11y-img-container');
+  
+          const subtitle = document.createElement('span');
+          subtitle.setAttribute('aria-hidden', 'true');
+          subtitle.textContent = altText;
+          subtitle.classList.add('github-a11y-img-caption');
+          
+          image.insertAdjacentElement('afterend', subtitle);
+      }
+    });
+  
+    // Appends heading level to headings. This is hidden from accesibility tree.
+    commentBody.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach(function(heading) {
+      heading.classList.add('github-a11y-heading');
+      const headingPrefix = document.createElement('span');
+  
+      headingPrefix.setAttribute('aria-hidden', 'true');
+      headingPrefix.classList.add('github-a11y-heading-prefix');
+      headingPrefix.textContent = ` ${heading.tagName.toLowerCase()}`;
+  
+      heading.append(headingPrefix);
+    });
   });
+ }
 
-  // Appends heading level to headings. This is hidden from accesibility tree.
-  commentBody.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach(function(heading) {
-    heading.classList.add('github-a11y-heading');
-    const headingPrefix = document.createElement('span');
-
-    headingPrefix.setAttribute('aria-hidden', 'true');
-    headingPrefix.classList.add('github-a11y-heading-prefix');
-    headingPrefix.textContent = ` ${heading.tagName.toLowerCase()}`;
-
-    heading.append(headingPrefix);
-  });
+ chrome.runtime.onMessage.addListener(async (message) => {
+  document.querySelectorAll(".github-a11y-img-caption").forEach(el => el.remove());
+  document.querySelectorAll(".github-a11y-heading-prefix").forEach(el => el.remove());
+  appendAccessibilityInfo();
 });
+
+appendAccessibilityInfo();

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,6 @@
   "content_scripts": [
     {
       "matches": ["https://*.github.com/*"],
-      "run_at": "document_idle",
       "css": ["styles.css"],
       "js": ["contentScript.js"]
 
@@ -16,5 +15,5 @@
   "background": {
     "scripts": ["background.js"]
   },
-  "permissions": ["*://github.com/*", "tabs", "webNavigation"]
+  "permissions": ["*://*.github.com/*", "tabs", "webNavigation"]
 }


### PR DESCRIPTION
This PR fixes a bug where the heading levels get appended multiple times to a page when using the back and forth button, or when clicking the tab of a page we're already on multiple times.

To prevent this, we should clean up the DOM whenever `onHistoryStateUpdated` events are fired (indicating page navigation). We do not need to do this on initial page load.

### Screenshot of bug
<img width="615" alt="Screen shot of bug where heading level text appears 3 times after the heading level" src="https://user-images.githubusercontent.com/16447748/153793576-3d042e99-3c70-4401-a831-36a462b26492.png">

