### PR TITLE
Fix alt overlay issue and deprecate support outside `github.com` and `gist.github.com` host.

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -23,10 +23,10 @@ function appendAccessibilityInfo() {
       if (!altText) {
           image.classList.add('github-a11y-img-missing-alt')
       } else {
-          const closestParagraph = image.closest('p');
-          if (!closestParagraph) return;
+          const parentElement = image.parentElement;
+          if (!parentElement) return;
   
-          closestParagraph.classList.add('github-a11y-img-container');
+          parentElement.classList.add('github-a11y-img-container');
   
           const subtitle = document.createElement('span');
           subtitle.setAttribute('aria-hidden', 'true');

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
   "version": "0.3",
   "content_scripts": [
     {
-      "matches": ["https://*.github.com/*"],
+      "matches": ["https://github.com/*", "https://gist.github.com/*"],
       "css": ["styles.css"],
       "js": ["contentScript.js"]
 
@@ -15,5 +15,5 @@
   "background": {
     "scripts": ["background.js"]
   },
-  "permissions": ["*://*.github.com/*", "tabs", "webNavigation"]
+  "permissions": ["*://github.com/*", "https://gist.github.com/*", "tabs", "webNavigation"]
 }

--- a/styles.css
+++ b/styles.css
@@ -2,11 +2,12 @@
 .github-a11y-img-container {
   display: inline-block;
   vertical-align: top;
+  border: 2px solid grey;
 }
 
 /* Styling for when image is missing alt text */
 .github-a11y-img-missing-alt {
-  border: 10px solid red;
+  border: 5px solid red;
 }
 
 /* Styling for image overlay */
@@ -19,9 +20,9 @@
   left: 0;  */
   font-weight: 700; 
   z-index: 2; 
-  max-width: fit-content; 
-  font-size: 0.85rem; 
-  opacity: 0.6;
+  width: 100%;
+  font-size: 0.8rem;
+  opacity: 0.8;
 }
 
 /* Styling for heading level text. */

--- a/styles.css
+++ b/styles.css
@@ -1,8 +1,7 @@
 /* For image overlay positioning */
 .github-a11y-img-container {
-  position: relative; 
-  padding: 0; 
-  margin: 0;
+  display: inline-block;
+  vertical-align: top;
 }
 
 /* Styling for when image is missing alt text */
@@ -16,13 +15,12 @@
   background-color: #121212; 
   padding: 0.5em; 
   color: white; 
-  position: absolute; 
-  bottom: 0.5em; 
-  left: 0; 
+  /* bottom: 0.5em; 
+  left: 0;  */
   font-weight: 700; 
   z-index: 2; 
-  width: 100%; 
-  font-size: 1.0rem; 
+  max-width: fit-content; 
+  font-size: 0.85rem; 
   opacity: 0.6;
 }
 
@@ -36,6 +34,7 @@
   display: table; 
   width: 100%;
 }
+
 .github-a11y-heading-prefix-after {
   display: table-cell; 
   text-align: right;


### PR DESCRIPTION
Fixes https://github.com/khiga8/github-a11y/issues/12

### Context

Previously the text overlay was styled to appear over the image. This resulted in text covering the image. Another problem was that when there were multiple images on the same line, the captions for each image will overlap on top of each other. 

Instead, we have the text overlay appear below the image and a border outlining the image and overlay to group it together. Additionally, we ensure that the alt text overlay is added when image is nested inside `table` and other elements, not just `<p>`.

This also turns off the extension outside of the `github.com` and `gist.github.com` domain where support may be wonky.

### Screenshots
#### Before:
<img width="824" alt="screenshot of three images appearing horizontally inline. the text overlay for each image overlaps on top of each other making it unreadable" src="https://user-images.githubusercontent.com/16447748/154205285-bb08f9d8-ecb7-4c55-ab58-264be262ada9.png">

<img width="784" alt="screenshot of text overlay missing  when image is nested inside a table cell" src="https://user-images.githubusercontent.com/16447748/154302453-d1f5b2d8-1870-424f-a89f-5798107108b5.png">


#### After:
<img width="853" alt="screenshot of text overlay appearing below each of the three images without overlapping on each other or the image" src="https://user-images.githubusercontent.com/16447748/154203632-d7c04444-2142-40e9-bb7d-5883d9ee02fd.png">

<img width="748" alt="screenshot of text overlay appearing over each image nested inside a table cell" src="https://user-images.githubusercontent.com/16447748/154302174-c4139822-cbad-49f5-8e9d-9fbc27454c31.png">

