### PR TITLE
Run accessibility scanner when previewing markdown

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -16,6 +16,11 @@ function addHeadingToFront(heading, headingPrefix) {
 }
 
 function appendAccessibilityInfo() {
+  const elements = document.querySelectorAll('.github-a11y-heading-prefix, .github-a11y-img-caption')
+  for (const element of elements) {
+    element.remove();
+  }
+
   document.querySelectorAll('.markdown-body').forEach(function(commentBody) {
     // Adds alt image overlay. This is hidden from accesibility tree.
     commentBody.querySelectorAll('img').forEach(function(image) {
@@ -45,16 +50,10 @@ function appendAccessibilityInfo() {
       addHeadingToBack(heading, headingPrefix); // Swappable with `addHeadingToFront`
     });
   });
- }
-
-function cleanup() {
-  document.querySelectorAll(".github-a11y-img-caption").forEach(el => el.remove());
-  document.querySelectorAll(".github-a11y-heading-prefix").forEach(el => el.remove());
 }
 
 /* Listen for messages from the background script */
-chrome.runtime.onMessage.addListener(async () => {
-  cleanup();
+chrome.runtime.onMessage.addListener(() => {
   appendAccessibilityInfo();
 });
 

--- a/contentScript.js
+++ b/contentScript.js
@@ -58,3 +58,16 @@ chrome.runtime.onMessage.addListener(() => {
 });
 
 appendAccessibilityInfo();
+
+const observer = new MutationObserver(function(mutationList) {
+  for (const mutation of mutationList) {
+    if (mutation.target.matches('.markdown-body')) {
+      appendAccessibilityInfo();
+    }
+  }
+})
+
+observer.observe(document.body, {
+  childList: true,
+  subtree: true
+});


### PR DESCRIPTION
This PR sets up a MutationObserver to scan for accessbility issues when a user previews their markdown text.

Closes #2
