### PR TITLE
make it easy to customize heading color

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ This extension will only run on GitHub domain and does the folowing on all markd
 
 ### Customization note
 
-This is currently not customizable and the styling I've set may not be suitable for all users. Feel free to customize this however you like when you download these files. You can do this by modifying `styles.css` to your preferred styling. If you'd prefer the headings to be positioned at front, follow the notes in `contentScript.js`. Then press `Update` on `chrome://extensions/` so changes are reflected in extension.
+The styling I've set may not be suitable for all users. Feel free to customize this however you like when you download these files. 
+
+You can do this by modifying `styles.css`. There are CSS variables at the top which you may set to your preferred colors. For example, you may choose to set a different color for each heading level, or add a border for distinguishability. If you'd prefer the headings to be positioned at front, follow the notes in `contentScript.js`. Once changes are made, `Update` on `chrome://extensions/` so changes are reflected in extension.
 
 ## Resources
 

--- a/contentScript.js
+++ b/contentScript.js
@@ -12,6 +12,7 @@ function addHeadingToBack(heading, headingPrefix) {
 function addHeadingToFront(heading, headingPrefix) {
   headingPrefix.textContent = `${heading.tagName.toLowerCase()} `;
   headingPrefix.classList.add('github-a11y-heading-prefix');
+  heading.classList.add('github-a11y-heading');
   heading.insertBefore(headingPrefix, heading.firstChild);
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1,21 +1,36 @@
+:root {
+  /* Feel free to customize colors to your preference */
+  --github-a11y-h1-color: purple;
+  --github-a11y-h2-color: purple;
+  --github-a11y-h3-color: purple;
+  --github-a11y-h4-color: purple;
+  --github-a11y-h5-color: purple;
+  --github-a11y-h6-color: purple;
+  --github-a11y-heading-border: none; /* set to solid if you prefer heading border for more visibility */
+  --github-a11y-img-invalid-border-color: red;
+  --github-a11y-img-valid-border-color: grey;
+  --github-a11y-img-overlay-background-color: black;
+  --github-a11y-img-overlay-text-color: white;
+}
+
 /* For image overlay positioning */
 .github-a11y-img-container {
   display: inline-block;
   vertical-align: top;
-  border: 2px solid grey;
+  border: 2px solid var(--github-a11y-img-valid-border-color); 
 }
 
 /* Styling for when image is missing alt text */
 .github-a11y-img-missing-alt {
-  border: 5px solid red;
+  border: 5px solid var(--github-a11y-img-invalid-border-color); 
 }
 
 /* Styling for image overlay */
 .github-a11y-img-caption {
   display: block; 
-  background-color: #121212; 
+  background-color: var(--github-a11y-img-overlay-background-color); 
   padding: 0.5em; 
-  color: white; 
+  color: var(--github-a11y-img-overlay-text-color);
   z-index: 2; 
   width: 100%;
   opacity: 0.8;
@@ -32,10 +47,59 @@
   font-size: 0.6rem;
 }
 
-/* Styling for heading level text. */
-.github-a11y-heading-prefix {
-  color: purple; 
+.markdown-body h1.github-a11y-heading {
+  border-bottom: 1px var(--github-a11y-heading-border) var(--github-a11y-h1-color); 
 }
+
+.markdown-body h1 > .github-a11y-heading-prefix, 
+.markdown-body h1.github-a11y-heading-prefix {
+  color: var(--github-a11y-h1-color); 
+}
+
+.markdown-body h2.github-a11y-heading {
+  border-bottom: 1px var(--github-a11y-heading-border) var(--github-a11y-h2-color); 
+}
+
+.markdown-body h2 > .github-a11y-heading-prefix, 
+.markdown-body h2.github-a11y-heading-prefix {
+  color: var(--github-a11y-h2-color); 
+}
+
+.markdown-body h3.github-a11y-heading {
+  border-bottom: 1px var(--github-a11y-heading-border) var(--github-a11y-h3-color); 
+}
+
+.markdown-body h3 > .github-a11y-heading-prefix, 
+.markdown-body h3.github-a11y-heading-prefix {
+  color: var(--github-a11y-h3-color); 
+}
+
+.markdown-body h4.github-a11y-heading {
+  border-bottom: 1px var(--github-a11y-heading-border) var(--github-a11y-h4-color);
+}
+
+.markdown-body h4 > .github-a11y-heading-prefix, 
+.markdown-body h4.github-a11y-heading-prefix {
+  color: var(--github-a11y-h4-color); 
+}
+
+.markdown-body h5.github-a11y-heading {
+  border-bottom: 1px var(--github-a11y-heading-border) var(--github-a11y-h5-color);
+}
+
+.markdown-body h5 > .github-a11y-heading-prefix, 
+.markdown-body h5.github-a11y-heading-prefix {
+  color: var(--github-a11y-h5-color); 
+}
+
+.markdown-body h6.github-a11y-heading {
+  border-bottom: 1px var(--github-a11y-heading-border) var(--github-a11y-h6-color);
+}
+
+.markdown-body h6 > .github-a11y-heading-prefix, 
+.markdown-body h6.github-a11y-heading-prefix {
+  color: var(--github-a11y-h6-color); 
+} 
 
 /* Used to position heading at end of line. See `contentScript.js` if you'd like heading at front */
 .github-a11y-heading-after {


### PR DESCRIPTION
This PR is a refactor that makes it easier for consumers to customize colors to their preference by updating CSS variables in `styles.css`.


<img width="900" alt="Screen of appended headings, each which correspond to different color due to customization" src="https://user-images.githubusercontent.com/16447748/154325975-78579d80-825b-4c3a-9852-5db5c89dab91.png">

