### PR TITLE
Run scan when change to js-commit-preview is observed

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -69,7 +69,7 @@ appendAccessibilityInfo();
 
 const observer = new MutationObserver(function(mutationList) {
   for (const mutation of mutationList) {
-    if (mutation.target.matches('.markdown-body')) {
+    if (mutation.target.matches('.markdown-body') || mutation.target.matches('.js-commit-preview')) {
       appendAccessibilityInfo();
     }
   }


### PR DESCRIPTION
Fixes https://github.com/khiga8/github-a11y/issues/17

This presumably has to do with how content of `js-commit-preview` changes and `markdown-body` is injected in as a child element. Not sure why `MutationObserver` doesn't have a mutation for `markdown-body`, but this fixes this issue in the interim.