### PR TITLE
Set default to border bottom

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This extension will only run on GitHub domain and does the folowing on all markd
 
 The styling I've set may not be suitable for all users. Feel free to customize this however you like when you download these files. 
 
-You can do this by modifying `styles.css`. There are CSS variables at the top which you may set to your preference. For example, you may choose to set a different color for each heading level, or add a border for distinguishability. These customizations can be very helpful for visual processing. If you'd prefer the headings to be positioned at front, follow the notes in `contentScript.js`. Once changes are made, `Update` on `chrome://extensions/` so changes are reflected in extension.
+You can do this by modifying `styles.css`. There are CSS variables at the top which you may set to your preference. For example, you may choose to set a different color for each heading level, or set a border for distinguishability. These customizations can be very helpful for visual processing. If you'd prefer the headings to be positioned at front, follow the notes in `contentScript.js`. Once changes are made, `Update` on `chrome://extensions/` so changes are reflected in extension.
 
 #### Example customization
 <img width="907" alt="Screen shot of example customization with each heading level assigned to a different color, and an underline with the color" src="https://user-images.githubusercontent.com/16447748/154328368-0336790d-4e54-4ed5-b7b0-4a10af32dbe1.png">

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ This extension will only run on GitHub domain and does the folowing on all markd
 
 - Appends the heading level that is used after the heading text within markdown bodies. Heading levels are useful for conveying semantics for screen reader, and other assistive technology users. This similarly aims to bring mindfulness particularly for sighted users who may pay less attention to heading level semantics.
 
-<img width="600" alt="Example screenshots of purple heading levels appended in at end of heading text line inside a GitHub markdown" src="https://user-images.githubusercontent.com/16447748/153683612-1b7d5975-ed45-4985-892d-6fd64545d18d.png">
+<img width="600" alt="Example screenshots of purple heading levels appended in at end of heading text line inside a GitHub markdown" src="https://user-images.githubusercontent.com/16447748/154616579-0db0bba3-4edb-4523-a89d-0c91888acbe0.png">
+
 
 ### Customization note
 

--- a/styles.css
+++ b/styles.css
@@ -6,7 +6,7 @@
   --github-a11y-h4-color: purple;
   --github-a11y-h5-color: purple;
   --github-a11y-h6-color: purple;
-  --github-a11y-heading-border: none; /* set to solid if you prefer heading border for more visibility */
+  --github-a11y-heading-border: solid; /* set to none if you prefer no heading border */
   --github-a11y-img-invalid-border-color: red;
   --github-a11y-img-valid-border-color: grey;
   --github-a11y-img-overlay-background-color: black;


### PR DESCRIPTION
Sets the default style to have border for heading text. 
This is helpful for readability.