### PR TITLE
set each heading to different color

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This assumes you are using a Google Chrome browser.
 3. Select `Load unpacked`.
 4. Choose this unzipped repo folder.
 5. Navigate to github.com.
-6. **Optional but highly recommended**: Set custom styles. Learn more in [Customization note](#customization-note).
+6. **Optional but recommended**: Set custom styles to your preference. Learn more in [Customization note](#customization-note).
 
 ## Features
 
@@ -25,17 +25,13 @@ This extension will only run on GitHub domain and does the folowing on all markd
 
 - Appends the heading level that is used after the heading text within markdown bodies. Heading levels are useful for conveying semantics for screen reader, and other assistive technology users. This similarly aims to bring mindfulness particularly for sighted users who may pay less attention to heading level semantics.
 
-<img width="600" alt="Example screenshots of purple heading levels appended in at end of heading text line inside a GitHub markdown" src="https://user-images.githubusercontent.com/16447748/154616579-0db0bba3-4edb-4523-a89d-0c91888acbe0.png">
-
+<img width="600" alt="Example screenshots of heading levels appended at end of heading text line inside a GitHub markdown" src="https://user-images.githubusercontent.com/16447748/154616579-0db0bba3-4edb-4523-a89d-0c91888acbe0.png">
 
 ### Customization note
 
-The styling I've set may not be suitable for all users. Feel free to customize this however you like when you download these files. 
+The styling I've set may not be suitable for all users. Feel free to customize these however you like when you download these files. 
 
-You can do this by modifying `styles.css`. There are CSS variables at the top which you may set to your preference. For example, you may choose to set a different color for each heading level, or set a border for distinguishability. These customizations can be very helpful for visual processing. If you'd prefer the headings to be positioned at front, follow the notes in `contentScript.js`. Once changes are made, `Update` on `chrome://extensions/` so changes are reflected in extension.
-
-#### Example customization
-<img width="907" alt="Screen shot of example customization with each heading level assigned to a different color, and an underline with the color" src="https://user-images.githubusercontent.com/16447748/154328368-0336790d-4e54-4ed5-b7b0-4a10af32dbe1.png">
+You can do this by modifying `styles.css`. There are CSS variables at the top which you may set to your preference. For example, you may choose to set a different color for each heading level or remove the border. If you'd prefer the headings to be positioned at front, follow the notes in `contentScript.js`. Once changes are made, `Update` on `chrome://extensions/` so changes are reflected in extension.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ This extension will only run on GitHub domain and does the folowing on all markd
 
 - Appends the heading level that is used after the heading text within markdown bodies. Heading levels are useful for conveying semantics for screen reader, and other assistive technology users. This similarly aims to bring mindfulness particularly for sighted users who may pay less attention to heading level semantics.
 
-<img width="600" alt="Example screenshots of heading levels appended at end of heading text line inside a GitHub markdown" src="https://user-images.githubusercontent.com/16447748/154616579-0db0bba3-4edb-4523-a89d-0c91888acbe0.png">
+<img width="600" alt="Example screenshots of heading levels appended at end of heading text line inside a GitHub markdown, each represented by a different color" src="https://user-images.githubusercontent.com/16447748/154763325-57ad4785-691c-4760-b0ca-b2e3cabacd1f.png">
+
 
 ### Customization note
 

--- a/styles.css
+++ b/styles.css
@@ -1,11 +1,11 @@
 :root {
   /* Feel free to customize colors to your preference */
-  --github-a11y-h1-color: purple;
-  --github-a11y-h2-color: purple;
-  --github-a11y-h3-color: purple;
-  --github-a11y-h4-color: purple;
-  --github-a11y-h5-color: purple;
-  --github-a11y-h6-color: purple;
+  --github-a11y-h1-color: #9B59B6;
+  --github-a11y-h2-color: #2A7AB0;
+  --github-a11y-h3-color: #9F6B3F;
+  --github-a11y-h4-color: #5A781D;
+  --github-a11y-h5-color: #d4521f;
+  --github-a11y-h6-color: #4D6066;
   --github-a11y-heading-border: solid; /* set to none if you prefer no heading border */
   --github-a11y-img-invalid-border-color: red;
   --github-a11y-img-valid-border-color: grey;


### PR DESCRIPTION
For quicker visual processing, I think it's helpful to have each heading level represent a different color. Therefore I am making this the default instead of a single purple color represent all heading levels. If consumers do not like this default, they can choose their own customizations following instructions in the README.

I used http://colorsafe.co/ to vet out colors that meet WCAG color contrast requirements, but some may find these colors unsuitable.

<img width="916" alt="Screen shot of extension appending heading levels to GitHub markdown with heading text. Each heading level has a different color" src="https://user-images.githubusercontent.com/16447748/154762440-214e91ad-a131-4748-8c99-c478c3e7ebd5.png">

