### PR TITLE
fix: make sure extension works with recent navigation changes

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -79,3 +79,11 @@ observer.observe(document.body, {
   childList: true,
   subtree: true
 });
+
+document.addEventListener('turbo:load', () => {
+  appendAccessibilityInfo();
+  observer.observe(document.body, {
+    childList: true,
+    subtree: true
+  });
+})


### PR DESCRIPTION
Fixes https://github.com/khiga8/github-a11y/issues/23

This extension started working only on page refreshes due to recent navigation changes.
This adds an `eventListener` for turbo load events to ensure this extension works properly when turbo is being used.