### PR TITLE
bug: avoid page crash

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -65,14 +65,21 @@ chrome.runtime.onMessage.addListener(() => {
   appendAccessibilityInfo();
 });
 
-const observer = new MutationObserver(function(mutationList) {
-  for (const mutation of mutationList) {
-    observer.disconnect();
-    if (mutation.target.closest('.markdown-body')) {
-      appendAccessibilityInfo();
+appendAccessibilityInfo();
+
+/* Debounce to avoid redundant appendAccessibilityInfo calls */
+let timer;
+let observer = new MutationObserver(function(mutationList) {
+  if (timer) clearTimeout(timer);
+  timer = setTimeout(() => {
+    for (const mutation of mutationList) {
+      observer.disconnect();
+      if (mutation.target.closest('.markdown-body')) {
+        appendAccessibilityInfo();
+      }
+      observe();
     }
-    observe();
-  }
+  }, 100);
 })
 
 const observe = ()=> {
@@ -80,7 +87,6 @@ const observe = ()=> {
     childList: true,
     subtree: true
   });
-
 };
 
 document.addEventListener('turbo:load', () => {

--- a/contentScript.js
+++ b/contentScript.js
@@ -65,25 +65,25 @@ chrome.runtime.onMessage.addListener(() => {
   appendAccessibilityInfo();
 });
 
-appendAccessibilityInfo();
-
 const observer = new MutationObserver(function(mutationList) {
   for (const mutation of mutationList) {
-    if (mutation.target.matches('.markdown-body') || mutation.target.matches('.js-commit-preview')) {
+    observer.disconnect();
+    if (mutation.target.closest('.markdown-body')) {
       appendAccessibilityInfo();
     }
+    observe();
   }
 })
 
-observer.observe(document.body, {
-  childList: true,
-  subtree: true
-});
-
-document.addEventListener('turbo:load', () => {
-  appendAccessibilityInfo();
+const observe = ()=> {
   observer.observe(document.body, {
     childList: true,
     subtree: true
   });
+
+};
+
+document.addEventListener('turbo:load', () => {
+  appendAccessibilityInfo();
+  observe();
 })


### PR DESCRIPTION
This PR makes a couple of updates:

- fix bug where page crashes when I go to `Notifications` from home page. This is a recent issue I've been noticing. I think there might be an infinite mutation loop happening when I go from GitHub home to Notifications. I am unable to hit a breakpoint when I try to debug, but adding `observer.disconnect();` call within the callback fixes the issue.
- adds an interval to debounce making the `appendAccessibilityInfo` updates
- updates the selector we listen to from `mutation.target.matches('.markdown-body')` to `mutation.target.closest('.markdown-body')`