### PR TITLE
Ensure support in code views

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -120,7 +120,7 @@ let observer = new MutationObserver(function (mutationList) {
   timer = setTimeout(() => {
     for (const mutation of mutationList) {
       observer.disconnect();
-      if (mutation.target.closest(".markdown-body, .js-commit-preview") && !mutation.target.classList.contains("github-a11y-heading") && !mutation.target.classList.contains("github-a11y-img-container")) {
+      if ((mutation.target.closest(".markdown-body, .js-commit-preview") || mutation.target.querySelector('.markdown-body')) && !mutation.target.classList.contains("github-a11y-heading") && !mutation.target.classList.contains("github-a11y-img-container")) {
         appendAccessibilityInfo();
       }
       observe();


### PR DESCRIPTION
In some views, I noticed the Write/Preview doesn't trigger the DOM updates. It seems like our current logic won't capture if the `mutation.target` is a parent of `.markdown-body`, so this updates the logic to also add support for is `mutation.target` contains `.markdown-body`.