### PR TITLE
Update manifest regex

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,12 +6,12 @@
   "version": "0.6",
   "content_scripts": [
     {
-      "matches": ["https://*.*.github.com/*", "https://github.com/*", "https://gist.github.com/*"],
+      "matches": ["https://*.github.com/*", "https://github.com/*"],
       "css": ["styles.css"],
       "js": ["contentScript.js"]
     },
     {
-      "matches": ["https://*.*.github.com/*", "https://github.com/*", "https://gist.github.com/*"],
+      "matches": ["https://*.github.com/*", "https://github.com/*"],
       "css": ["./devtools-feedback/contentScriptStyles.css"],
       "js": ["./devtools-feedback/contentScript.js"]
     }
@@ -20,7 +20,7 @@
     "service_worker": "background.js"
   },
   "permissions": ["tabs", "webNavigation"],
-  "host_permissions": ["*://*.*.github.com/*", "*://github.com/*", "https://gist.github.com/*"],
+  "host_permissions": ["*://*.github.com/*", "*://github.com/*"],
   "web_accessible_resources": [
     {
       "resources": ["src/*"],


### PR DESCRIPTION
👋🏼 @khiga8! Thanks for making this!

It appears as though the [previous commit](https://github.com/khiga8/github-a11y/commit/b3b8326a29647d648a2661ce1d87bca79e409458) changed the regex so that it would accept more subdomains, however, the syntax `*.*` broke the extension so that it could no longer be loaded.

For reference: [Chrome extensions match patterns](https://developer.chrome.com/docs/extensions/mv3/match_patterns/)

<img width="596" alt="Screenshot of upload error in Chrome" src="https://github.com/khiga8/github-a11y/assets/9965014/fdedf45f-0e25-4f83-8eb3-00d45abd97f2">

When changed to `*.github.com` the plugin uploads and works (I see it working on the image above). 

Additionally, I removed `https://gist.github.com` because it's redundant because it is included by the wildcard. 
