### PR TITLE
feat: excludes emoji from a11y container with alt caption

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -113,6 +113,11 @@ function validateImagesWithAnchorParent(parent, image) {
 }
 
 function validateImagesWithNonAnchorParent(parent, image) {
+  const isEmoji = image.classList.contains("emoji");
+  if (isEmoji) {
+    return;
+  }
+
   const hasAltTextAttribute = image.hasAttribute("alt");
   const altText = hasAltTextAttribute && image.getAttribute("alt").trim();
   if (!hasAltTextAttribute) {

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -195,6 +195,22 @@ describe("validateImages", () => {
       expect(document.querySelector(".github-a11y-img-invalid-alt")).toBe(null);
     });
 
+    test("does not flag if image is an emoji", () => {
+      console.log("am i run");
+      document.body.innerHTML = `
+        <p id="cat">
+          <img class="emoji" alt="Some cat." src="some_cat.png" />
+        </p>
+      `;
+      const parent = document.querySelector("#cat");
+      const img = document.querySelector("img");
+      validateImages(parent, img);
+      const captionContainer = document.querySelector(
+        ".github-a11y-img-container"
+      );
+      expect(captionContainer).toBe(null);
+    });
+
     test("surfaces alt if image has alt", () => {
       document.body.innerHTML = `
         <p id="cat">


### PR DESCRIPTION
GitHub allows emoji content in descriptions. As of now, the extension will add the caption container to this emoji, which makes reading of flow content a bit awkward.

I'm proposing that we bypass this specifically for emojis, although I do know that emoji management inside text is an accessibility concern. Maybe there's some other way to surface this, however? 

Examples:
Sometimes we render an octocat :octocat: in our text descriptions. For some reason, it seems to be handled differently from other emoji like the 100 (💯) and thumbs up (👍).