### PR TITLE
fix: applies alt text only once

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -23,11 +23,7 @@ export function appendAccessibilityInfo() {
 
   document.querySelectorAll(".markdown-body").forEach(function (commentBody) {
     commentBody.querySelectorAll("img").forEach(function (image) {
-      const parentNodeName = image.parentElement.nodeName;
-      if (parentNodeName === "A" || parentNodeName === "P") {
-        const parent = image.closest("a") || image.closest("p");
-        validateImages(parent, image);
-      }
+      validateImages(image.closest("a") || image.closest("p"), image);
     });
 
     commentBody

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,7 +23,11 @@ export function appendAccessibilityInfo() {
 
   document.querySelectorAll(".markdown-body").forEach(function (commentBody) {
     commentBody.querySelectorAll("img").forEach(function (image) {
-      validateImages(image.closest("a") || image.closest("p"), image);
+      const parentNodeName = image.parentElement.nodeName;
+      if (parentNodeName === "A" || parentNodeName === "P") {
+        const parent = image.closest("a") || image.closest("p");
+        validateImages(parent, image);
+      }
     });
 
     commentBody

--- a/src/utils.js
+++ b/src/utils.js
@@ -101,6 +101,9 @@ function validateImagesWithAnchorParent(parent, image) {
     image.classList.add("github-a11y-img-invalid-alt");
   }
 
+  if (parent.querySelector('.github-a11y-img-caption')) {
+    return;
+  }
   const subtitle = createSubtitleElement();
   parent.classList.add("github-a11y-img-container");
 
@@ -122,6 +125,9 @@ function validateImagesWithNonAnchorParent(parent, image) {
   }
   if (invalidAltText(altText)) {
     image.classList.add("github-a11y-img-invalid-alt");
+  }
+  if (parent.querySelector('.github-a11y-img-caption')) {
+    return;
   }
   const subtitle = createSubtitleElement();
   parent.classList.add("github-a11y-img-container");


### PR DESCRIPTION
I was seeing a double caption on some images, this resolves it by early returning just before adding the subtitle if there's already a caption class on the image.