### PR TITLE
fix: heading text appears twice

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -22,6 +22,12 @@ export function appendAccessibilityInfo() {
   removeOutdatedElements();
 
   document.querySelectorAll(".markdown-body").forEach(function (commentBody) {
+    // On GitHub Issues, .markdown-body is set twice on the same markdownbody. div.markdown-body > div.markdown-body
+    // To avoid setting annotation twice, early return.
+    if (commentBody.querySelectorAll(
+      ".github-a11y-heading-prefix, .github-a11y-img-caption"
+    ).length > 0) return
+
     commentBody.querySelectorAll("img").forEach(function (image) {
       const parentNodeName = image.parentElement.nodeName;
       if (parentNodeName === "A" || parentNodeName === "P") {


### PR DESCRIPTION
Follow-up to https://github.com/khiga8/github-a11y/pull/57

This ensures that heading text isn't annotated twice on a markdown body.

Currently, when this extensions runs on GitHub Issues, heading text is annotated twice.

This happens because:
* we use  `.markdown-body`  to uniquely identify a markdown body. For whatever reason, on GitHub Issues specifically, `.markdown-body` gets set twice on the same markdown body (on different divs).
* When we query for `.markdown-body` and add annotations, we get back 2 `.markdown-body` for the same comment box. As a result, we end up with double annotations.

This PR adds early return logic. 
