### PR TITLE
fix: additional errors and animated player duplicates

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,6 @@ export async function initialize() {
   /* Listen for messages from the background script */
   chrome.runtime.onMessage.addListener((message, sendResponse) => {
     if (message.type === "navigation") {
-      sendResponse({ status: "ok" });
       appendAccessibilityInfo();
     }
   });

--- a/src/utils.js
+++ b/src/utils.js
@@ -28,7 +28,9 @@ export function appendAccessibilityInfo() {
       ".github-a11y-heading-prefix, .github-a11y-img-caption"
     ).length > 0) return
 
-    commentBody.querySelectorAll("img").forEach(function (image) {
+    [...commentBody.querySelectorAll("img")]
+      .filter(el => !el.closest('animated-image'))
+      .forEach(function (image) {
       const parentNodeName = image.parentElement.nodeName;
       if (parentNodeName === "A" || parentNodeName === "P") {
         const parent = image.closest("a") || image.closest("p");


### PR DESCRIPTION
* Remove unnecessary `sendResponse` call causing errors.
* Don't double render captions on GIFs, specifically when a user has "Sync with settings" enabled in their accessibility settings.

Before:
<img width="599" alt="Captions are being double rendered on a GIF" src="https://github.com/user-attachments/assets/387ebdfe-cbbb-4344-bfa5-66e4bd361b64" />



After:
<img width="558" alt="Captions are no longer double rendered on a GIF" src="https://github.com/user-attachments/assets/42dbd8e4-7907-45f0-8af3-50043eee4c6e" />
